### PR TITLE
Fix: Image Uploads

### DIFF
--- a/Http/Controllers/UploadLogoController.php
+++ b/Http/Controllers/UploadLogoController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\WhiteLabel\Http\Controllers;
 
+use App\Models\Company;
 use App\Models\CompanySetting;
 use App\Models\Setting;
 use Illuminate\Http\Request;
@@ -15,48 +16,80 @@ if (VersionHelper::checkAppVersion('<', '2.0.0')) {
 
 class UploadLogoController extends Controller
 {
+    const MEDIA_CUSTOMER_PORTAL_LOGO = 'customer_portal_logo';
+
+    const MEDIA_ADMIN_PORTAL_LOGO = 'admin_portal_logo';
+
+    const MEDIA_LOGIN_PAGE_LOGO = 'login_page_logo';
+
     public function uploadLogos(Request $request)
     {
         $adminPortalLogoUrl = null;
         $customerPortalLogoUrl = null;
         $loginPageLogoUrl = null;
 
-        if ($request->hasFile('customer_portal_logo')) {
-            $imageName = time().'.'.$request->customer_portal_logo->extension();
-            $request->customer_portal_logo->storeAs('public/whitelabel/customer_portal_logo/', $imageName);
+        $company = Company::find($request->header('company'));
 
-            $customerPortalLogoUrl = 'whitelabel/customer_portal_logo/'.$imageName;
+        if (isset($request->is_customer_portal_logo_removed) && (bool) $request->is_customer_portal_logo_removed) {
+            $company->clearMediaCollection(self::MEDIA_CUSTOMER_PORTAL_LOGO);
 
             $settings = [
-                'customer_portal_logo' => $customerPortalLogoUrl
+                'customer_portal_logo' => '',
             ];
 
             CompanySetting::setSettings($settings, $request->header('company'));
         }
 
-        if ($request->hasFile('admin_portal_logo')) {
-            $imageName = time().'.'.$request->admin_portal_logo->extension();
-            $request->admin_portal_logo->storeAs('public/whitelabel/admin_portal_logo/', $imageName);
+        if ($request->hasFile('customer_portal_logo')) {
+            $customerPortalLogoUrl = $this->addMedia($request, self::MEDIA_CUSTOMER_PORTAL_LOGO);
 
-            $adminPortalLogoUrl = 'whitelabel/admin_portal_logo/'.$imageName;
+            $settings = [
+                'customer_portal_logo' => $customerPortalLogoUrl,
+            ];
 
-            Setting::setSetting('admin_portal_logo', $adminPortalLogoUrl);
+            CompanySetting::setSettings($settings, $request->header('company'));
         }
 
-        if ($request->hasFile('login_page_logo')) {
-            $imageName = time().'.'.$request->login_page_logo->extension();
-            $request->login_page_logo->storeAs('public/whitelabel/login_page_logo/', $imageName);
+        if (isset($request->is_admin_portal_logo_removed)) {
+            $company->clearMediaCollection(self::MEDIA_ADMIN_PORTAL_LOGO);
+            Setting::setSetting(self::MEDIA_ADMIN_PORTAL_LOGO, $adminPortalLogoUrl);
+        }
 
-            $loginPageLogoUrl = 'whitelabel/login_page_logo/'.$imageName;
+        if ($request->hasFile(self::MEDIA_ADMIN_PORTAL_LOGO)) {
+            $adminPortalLogoUrl = $this->addMedia($request, self::MEDIA_ADMIN_PORTAL_LOGO);
+            Setting::setSetting(self::MEDIA_ADMIN_PORTAL_LOGO, $adminPortalLogoUrl);
+        }
 
-            Setting::setSetting('login_page_logo', $loginPageLogoUrl);
+        if (isset($request->is_login_page_logo_removed)) {
+            $company->clearMediaCollection(self::MEDIA_LOGIN_PAGE_LOGO);
+            Setting::setSetting(self::MEDIA_LOGIN_PAGE_LOGO, $loginPageLogoUrl);
+        }
+
+        if ($request->hasFile(self::MEDIA_LOGIN_PAGE_LOGO)) {
+            $loginPageLogoUrl = $this->addMedia($request, self::MEDIA_LOGIN_PAGE_LOGO);
+            Setting::setSetting(self::MEDIA_LOGIN_PAGE_LOGO, $loginPageLogoUrl);
         }
 
         return response()->json([
             'success' => true,
             'customerPortalLogoUrl' => $customerPortalLogoUrl,
             'adminPortalLogoUrl' => $adminPortalLogoUrl,
-            'loginPageLogoUrl' => $loginPageLogoUrl
+            'loginPageLogoUrl' => $loginPageLogoUrl,
         ], 200);
+    }
+
+    private function addMedia(Request $request, string $mediaName): string
+    {
+        $company = Company::find($request->header('company'));
+        $imageName = time().'.'.$request->file($mediaName)->extension();
+
+        $company->clearMediaCollection($mediaName);
+        $company->addMediaFromRequest($mediaName)
+            ->usingFileName($imageName)
+            ->toMediaCollection($mediaName);
+
+        $media = $company->getMedia($mediaName)->first();
+
+        return sprintf('%s/%s', $media->id, $media->file_name);
     }
 }

--- a/Resources/scripts/views/WhiteLabelSetting.vue
+++ b/Resources/scripts/views/WhiteLabelSetting.vue
@@ -216,33 +216,42 @@ utils.mergeSettings(adminPortalSettings, {
 })
 
 let customerLogoBlob = ref(null)
+let isCustomerLogoRemoved = ref(false)
 let adminLogoBlob = ref(null)
+let isAdminLogoRemoved = ref(false)
 let loginPageLogoBlob = ref(null)
+let isLoginPageLogoRemoved = ref(false)
 let isSavingCustomerSettings = ref(false)
 let isSavingAdminSettings = ref(false)
 
 function onCustomerLogoChange(fileName, file, fileCount, fileList) {
   customerLogoBlob.value = file
+  isCustomerLogoRemoved.value = false
 }
 
 function onCustomerLogoRemove() {
   customerLogoBlob.value = null
+  isCustomerLogoRemoved.value = true
 }
 
 function onAdminLogoChange(fileName, file, fileCount, fileList) {
   adminLogoBlob.value = file
+  isAdminLogoRemoved.value = false
 }
 
 function onAdminLogoRemove() {
   adminLogoBlob.value = null
+  isAdminLogoRemoved.value = true
 }
 
 function onLoginPageLogoChange(fileName, file, fileCount, fileList) {
   loginPageLogoBlob.value = file
+  isLoginPageLogoRemoved.value = false
 }
 
 function onLoginPageLogoRemove() {
   loginPageLogoBlob.value = null
+  isLoginPageLogoRemoved.value = true
 }
 
 async function saveCustomerPortalSettings() {
@@ -252,6 +261,10 @@ async function saveCustomerPortalSettings() {
 
   if (customerLogoBlob.value) {
     logoData.append('customer_portal_logo', customerLogoBlob.value)
+  }
+
+  if (isCustomerLogoRemoved.value) {
+    logoData.append("is_customer_portal_logo_removed", isCustomerLogoRemoved.value)
   }
 
   let logoRes = await whiteLogoStore.updateLogo(logoData)
@@ -280,8 +293,16 @@ async function saveAdminPortalSettings() {
     logoData.append('admin_portal_logo', adminLogoBlob.value)
   }
 
+  if (isAdminLogoRemoved.value) {
+    logoData.append('is_admin_portal_logo_removed', isAdminLogoRemoved.value)
+  }
+
   if (loginPageLogoBlob.value) {
     logoData.append('login_page_logo', loginPageLogoBlob.value)
+  }
+
+  if (isLoginPageLogoRemoved.value) {
+    logoData.append('is_login_page_logo_removed', isLoginPageLogoRemoved.value)
   }
 
   let logoRes = await whiteLogoStore.updateLogo(logoData)


### PR DESCRIPTION
When install the module and use it, the images updated won't show up because of the file permissions of the folder and files created, a way to solved it to re-run the permissions fixes.

However instead of uploading directly into an new folder, will be simple to use the media-library available into the InvoiceShelf.

With this in place, there is no need to re-run the permissions and everything will be uploaded correctly.

Previously there is no way to remove the images uploaded, once defined no change to removed, with that in mind, this issue was fixed by sending a request informing the removal of the image.